### PR TITLE
feat: add w&b logging support for the training loop

### DIFF
--- a/disentangled_rnns/library/rnn_utils.py
+++ b/disentangled_rnns/library/rnn_utils.py
@@ -30,8 +30,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import optax
 
-import wandb
-
 # If we're running on colab, try to import IPython.display so we can display
 # progress that way. Otherwise, we will just print.
 if 'google.colab' in sys.modules:

--- a/disentangled_rnns/library/rnn_utils.py
+++ b/disentangled_rnns/library/rnn_utils.py
@@ -149,7 +149,7 @@ class DatasetRNN:
     # Are xs and ys non-empty?
     if xs.shape[0] == 0 or xs.shape[1] == 0:
       raise ValueError(
-          'xs and ys must be non-empty. Got xs.shape = {xs.shape} and'
+          f'xs and ys must be non-empty. Got xs.shape = {xs.shape} and'
           f' ys.shape = {ys.shape} instead.'
       )
 

--- a/disentangled_rnns/library/rnn_utils.py
+++ b/disentangled_rnns/library/rnn_utils.py
@@ -444,6 +444,7 @@ def train_network(
     opt_state: Optional[optax.OptState] = None,
     params: Optional[hk.Params] = None,
     n_steps: int = 1000,
+    step_offset: int = 0,
     max_grad_norm: float = 1e10,
     loss_param: dict[str, float] | float = 1.0,
     loss: Literal[
@@ -472,6 +473,7 @@ def train_network(
     params:  A set of parameters suitable for the network given by make_network
       If not specified, will begin training a network from scratch
     n_steps: An integer giving the number of steps you'd like to train for
+    step_offset: An integer offset to add to the step count when logging
     max_grad_norm:  Gradient clipping. Default to a very high ceiling
     loss_param: Parameters to pass to the loss function. Can be a dictionary for
       fine-grained control over different loss components (e.g.,
@@ -685,7 +687,7 @@ def train_network(
 
       wandb.log(
         {"train/loss": loss, "valid/loss": l_validation},
-        step=step + 1
+        step=step + step_offset,
         )
 
       if report_progress_by == 'print':

--- a/disentangled_rnns/library/rnn_utils.py
+++ b/disentangled_rnns/library/rnn_utils.py
@@ -488,8 +488,8 @@ def train_network(
     wandb_run: Optional W&B run object used for logging metrics during train.
        W&B logging occurs only if both wandb_run is provided and
        report_progress_by is 'wandb'.
-    wandb_step_offset: Integer used to shift the logged step index
-      (e.g. to include warmup steps logged beforehand).
+    wandb_step_offset: Integer used to shift the W&B step count, if necessary
+       (e.g. to include warmup steps logged beforehand in the same W&B run).
 
   Returns:
     params: Trained parameters

--- a/disentangled_rnns/library/rnn_utils.py
+++ b/disentangled_rnns/library/rnn_utils.py
@@ -30,6 +30,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import optax
 
+import mlflow
+import wandb
+
 # If we're running on colab, try to import IPython.display so we can display
 # progress that way. Otherwise, we will just print.
 if 'google.colab' in sys.modules:
@@ -624,6 +627,16 @@ def train_network(
           f'Training Loss: {loss:.2e}. '
           f'Validation Loss: {l_validation:.2e}'
       )
+
+      mlflow.log_metrics({
+        "train/loss": loss,
+        "valid/loss": l_validation,
+        }, step=step + 1)
+
+      wandb.log(
+        {"train/loss": loss, "valid/loss": l_validation},
+        step=step + 1
+        )
 
       if report_progress_by == 'print':
         # On colab, print does not always work, so try to use display

--- a/disentangled_rnns/library/rnn_utils.py
+++ b/disentangled_rnns/library/rnn_utils.py
@@ -689,12 +689,15 @@ def train_network(
       )
 
       if report_progress_by == 'wandb' and wandb_run is not None:
-        wandb_run.log(
-            {"train/loss": loss, "valid/loss": l_validation},
-            step=step + wandb_step_offset,
-        )
+        try:
+          wandb_run.log(
+              {"train/loss": loss, "valid/loss": l_validation},
+              step=step + wandb_step_offset,
+          )
+        except Exception as e:
+          warnings.warn(f"W&B logging failed: {e}")
 
-      if report_progress_by == 'print' or report_progress_by == 'wandb':
+      if report_progress_by in ('print', 'wandb'):
         # On colab, print does not always work, so try to use display
         if _display_available:
           display.clear_output(wait=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 "scipy>=1.15, <2.0",
 "matplotlib>=3.9, <4.0",
 "absl-py>=2.1, <3.0",
+"wandb~=0.23.0",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
 "scipy>=1.15, <2.0",
 "matplotlib>=3.9, <4.0",
 "absl-py>=2.1, <3.0",
-"wandb~=0.23.0",
 ]
 
 


### PR DESCRIPTION
- When `report_progress_by` == 'wandb' and `wandb_run` is provided, train_network() will now log train and test losses to the W&B run for real time tracking.
- Also fixed a missing "f" in a ValueError message

- resolves #3 